### PR TITLE
Remove a couple special cases

### DIFF
--- a/lib/json/merge_patch.rb
+++ b/lib/json/merge_patch.rb
@@ -46,7 +46,7 @@ module JSON
     def merge(orig, patch)
       if is_array_or_primitive?(orig) || is_array_or_primitive?(patch)
         orig = patch
-      elsif patch.kind_of?(Hash)
+      else
         patch.each_key { |key| orig[key] = merge(orig[key], patch[key]) }
       end
 

--- a/lib/json/merge_patch.rb
+++ b/lib/json/merge_patch.rb
@@ -44,8 +44,6 @@ module JSON
     private
 
     def merge(orig, patch)
-      return nil if patch.nil?
-
       if is_array_or_primitive?(orig) || is_array_or_primitive?(patch)
         orig = patch
       elsif patch.kind_of?(Hash)
@@ -60,8 +58,10 @@ module JSON
     end
 
     def is_primitive?(val)
-      [String,    Fixnum,
-       TrueClass, FalseClass].include?(val.class)
+      [ String, Fixnum,
+        TrueClass, FalseClass,
+        NilClass
+      ].include?(val.class)
     end
 
     def purge_nils(obj)


### PR DESCRIPTION
This removes a couple special cases to simplify things a bit more.
- [`ad1a9ad4`](https://github.com/chrishunt/json-merge_patch/commit/ad1a9ad499d7599068857de062bf796f21d7086c) Removes the special case for `nil` since it's basically a primitive in Ruby anyway. Makes the code easier to read.
- [`7c7362da`](https://github.com/chrishunt/json-merge_patch/commit/7c7362dab9edf9ed714fc05940e483c4e2c113cd) Removes the unnecessary check for a hash. We already know at this point that we're dealing with a hash.
