### PR TITLE
Don't delete nulls inside Arrays

### DIFF
--- a/lib/json/merge_patch.rb
+++ b/lib/json/merge_patch.rb
@@ -44,31 +44,18 @@ module JSON
     private
 
     def merge(orig, patch)
-      if is_array_or_primitive?(orig) || is_array_or_primitive?(patch)
-        orig = patch
-      else
+      if orig.kind_of?(Hash) && patch.kind_of?(Hash)
         patch.each_key { |key| orig[key] = merge(orig[key], patch[key]) }
+      else
+        orig = patch
       end
 
       purge_nils orig
     end
 
-    def is_array_or_primitive?(obj)
-      obj.kind_of?(Array) || is_primitive?(obj)
-    end
-
-    def is_primitive?(val)
-      [ String, Fixnum,
-        TrueClass, FalseClass,
-        NilClass
-      ].include?(val.class)
-    end
-
     def purge_nils(obj)
-      return obj if is_primitive?(obj)
-      return obj.compact if obj.kind_of?(Array)
-
-      obj.delete_if {|k, v| v.nil? }
+      obj.delete_if {|k, v| v.nil? } if obj.kind_of?(Hash)
+      obj
     end
   end
 end

--- a/test/merge_patch_test.rb
+++ b/test/merge_patch_test.rb
@@ -91,9 +91,9 @@ describe "section 2" do
       it "replaces members" do
         document = %q'{"foo":"bar"}'
 
-        merge_patch = %q'{"foo":"baz"}'
+        merge_patch = %q'{"foo":"baz","dev":[null,"bar"]}'
 
-        expected = %q'{"foo":"baz"}'
+        expected = %q'{"foo":"baz","dev":[null,"bar"]}'
 
         assert_equal expected, JSON.merge(document, merge_patch)
       end


### PR DESCRIPTION
> **Part 3**
> If the value is either a non-null JSON primitive or an Array and that member
> is currently defined within the target resource, the existing value for that
> member is to be replaced with that provided. **Any object member contained in
> the provided data whose value is explicitly null is to be treated as if the
> member were undefined**

This could go either way, but it reads to me like we want to remove `null` _members_, but not necessarily nulls inside of Arrays.

Since Arrays are replaced entirely every time we patch, null doesn't have any special meaning inside an Array; it's just data.

Either way, [line #69](https://github.com/steveklabnik/json-merge_patch/blob/3067a80627499ffedbdf474dd1c2d62c8bd2d872/lib/json/merge_patch.rb#L69) can be deleted without failing any tests. We should modify the test in this PR to match whatever behavior we think is best. The implementation in this PR will allow nulls inside Arrays.
